### PR TITLE
feat: Add UNVR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,72 +1,107 @@
 # UNVR-NAS
 
-Firmware builder to convert your Unifi NVR Pro into an OpenMediaVault NAS appliance.
+Firmware builder to convert your Unifi NVR/Unifi NVR Pro into an OpenMediaVault NAS appliance.
 
 **This repo is still under heavy development and should be considered early alpha!**
 
 ## Supported Devices
 
+* UNVR **(Currently Untested!)**
 * UNVR Pro
-
-Note that the 1U UNVR is not currently supported as I do not have a unit to test on. PR's are welcome!
 
 ## Usage
 
-1. Download the required UNVRPro firmware, and place it in the unifi-firmware directory. Please see the README.md in that directory for more information.
+1. Download the required UNVR firmware for your device, and place it in the unifi-firmware directory. Please see the README.md in that directory for more information.
 2. Make sure your system has the required packages installed for this repo, which are:
 
     `docker-ce losetup wget sudo make qemu-user-static squashfs-tools`
 
-3. Run the tool, and sit back and wait for it to do it's thing. Depending on your computer, this may take around an hour or so. Also note near the end there will be some scary errors during debootstrap, but this is expected.
+3. Run make with your board name set, and sit back and wait for the firmware image to build. Depending on your computer, this may take around an hour or so.
 
-    `make`
+    For the UNVR: `BOARD=UNVR make`
 
-4. Once done, you will have a built disk image in ./output
+    For the UNVR Pro: `BOARD=UNVRPRO make`
+
+    * Also note that near the end of the image build process there will be some red text errors, but this is expected. This is due to the openmediavault install not being able to talk to systemd, as it's a debootstrap environment.
+
+4. Once done, you will have a compressed disk image in ./output
 
 ## Installation
 
 Note that currently the install process requires UART to modify the u-boot env for booting. In the future, if I can get the latest kernel GPL source, this will not be required.
 
-1. MAKE SURE your UNVR Pro is running the same Unifi firmware as referenced in the README.md in the unifi-firmware directory.
+1. MAKE SURE your UNVR/UNVR Pro is running the same Unifi firmware as referenced in the README.md in the unifi-firmware directory.
     * **Failure to do this can cause issues from the installation process not working, to the touch screen not working!**
-1. Build the firmware image (follow the Usage section), and then throw it on an HDD/SSD formatted to ext4. Put said HDD in the UNVR Pro as the only hard drive.
-2. Hook up UART to the UNVR Pro (4 pin header on the PCB near the DC Power Backup port).
-3. Boot the UNVR Pro, and press Escape twice when prompted to get to the u-boot shell. You only have 2 seconds to do this!
-4. Run the following commands to update the kernel cmdline and save the changes:
+
+2. Build the firmware image (follow the Usage section), and then throw it on an HDD/SSD formatted to ext4. Put said HDD in the UNVR/UNVR Pro as the only hard drive.
+
+3. Hook up UART to the UNVR/UNVR Pro:
+
+    On the UNVR, UART is located on the PCB behind the SFP+ cage, near the middle of the board (4 pins).
+
+    On the UNVR Pro, UART is located on the PCB near the DC Power Backup port (4 pins).
+
+4. Boot the UNVR/UNVR Pro, and in your UART console press Escape (Esc) twice when prompted to get to the u-boot shell. You only have 2 seconds to do this!
+5. Run the following commands to update the kernel cmdline and save the changes:
 
     ```
-    setenv rootfs /dev/boot2
+    setenv rootfs PARTLABEL=rootfs
     setenv bootargsextra boot=local rw
     saveenv
     ```
 
-5. Boot into recovery. This can be done using the command below, or by unplugging the UNVR Pro, and holding the reset button for 10~ seconds as you power it back up.
+6. Boot into recovery. This can be done using the command below, or by unplugging the UNVR/UNVR Pro, and holding the reset button for 10~ seconds as you power it back up.
 
     `run bootcmdrecovery`
 
-6. Once recovery is booted, login with `ubnt:ubnt` or `root:ubnt`. Note this can be done either via UART, or by telnet to the IP address your UNVR Pro display reports.
-7. Mount your HDD with the firmware image, backup the Unifi firmware, your u-boot env partitions, and then flash our custom firmware to the EMMC. (below command example assumes your ext4 disk partition is at /dev/sda1)
+7. Once recovery is booted, login with `ubnt:ubnt` or `root:ubnt`. Note this can be done either via UART shell, or if you want you can telnet into the IP address of your UNVR/UNVR Pro in recovery if you have it networked.
 
-    ```
-    mount /dev/sda1 /mnt
-    cd /mnt
-    dd if=/dev/boot of=/mnt/unvrpro-emmc-backup.bin bs=4M
-    dd if=/dev/mtd1 of=/mnt/unvrpro-mtd1-uboot-env.bin
-    dd if=/dev/mtd2 of=/mnt/unvrpro-mtd2-uboot-env-redundant.bin
-    gunzip debian-UNVRPRO.img.gz
-    dd if=./debian-UNVRPRO.img of=/dev/boot bs=4M
-    sync
-    reboot
-    ```
+8. Mount your HDD with the firmware image and then flash our custom firmware to the EMMC/Storage. (Note the examples below expect your HDD with the firmware to be at /dev/sda)
 
-8. At this point you can remove the HDD/SSD you used, and enjoy Debian 12 with OpenMediaVault on your UNVR Pro! Default login for OpenMediaVault is `admin:openmediavault`. SSH login information is `debian:debian`. Please note that first boot may take a bit as cloud-init runs to finish the setup.
+    * UNVR:
+
+        * Mount your disk to /mnt
+
+            ```
+            mount /dev/sda1 /mnt
+            ```
+
+        * Write the UNVR-NAS firmware image to the EMMC/Storage
+
+            Note that if you have an older UNVR with the internal USB drive, you will need to replace `/dev/boot` with the path of your USB drive!
+
+            ```
+            gunzip /mnt/debian-UNVR.img.gz
+            dd if=/mnt/debian-UNVR.img of=/dev/boot bs=4M
+            sync
+            reboot
+            ```
+
+    * UNVR Pro:
+
+        * Mount your disk to /mnt
+
+            ```
+            mount /dev/sda1 /mnt
+            ```
+
+        * Write the UNVR-NAS firmware image to the EMMC/Storage
+
+            ```
+            gunzip /mnt/debian-UNVRPRO.img.gz
+            dd if=/mnt/debian-UNVRPRO.img of=/dev/boot bs=4M
+            sync
+            reboot
+            ```
+
+9. At this point you can remove the HDD/SSD you used, and enjoy Debian 12 with OpenMediaVault on your UNVR/UNVR Pro! Default login for OpenMediaVault is `admin:openmediavault`. SSH login information is `debian:debian`. Please note that first boot may take a bit as cloud-init runs to finish the setup.
 
 ## Removal
 
-To restore back to the factory UNVR-Pro firmware, you can do the following steps:
+To restore back to the factory UNVR/UNVR Pro firmware, you can do the following steps:
 
 1. Hold the "reset" button on the front while powering on to boot into recovery
-2. Once the display shows it's in recovery, telnet to the IP address shown on the touch screen. At the login prompt, login with `ubnt:ubnt` or `root:ubnt`.
+2. Once the device is in recovery mode, telnet to the IP address if the device (the UNVR Pro will display this on the touch screen). At the login prompt, login with `ubnt:ubnt` or `root:ubnt`.
 3. Erase the uboot env, to remove our custom boot commands. This SHOULD be mtd1/mtd2, but **PLEASE VERIFY** first with `cat /proc/mtd` to prevent bricking your device! **DO NOT SKIP THIS STEP!** The output should match below, if not, **PLEASE DO NOT CONTINUE!**
     
     ```
@@ -90,6 +125,8 @@ To restore back to the factory UNVR-Pro firmware, you can do the following steps
 
 5. Next, erase the EMMC so all partitions are wiped:
 
+    Note that if you have an older UNVR with the internal USB drive, you will need to replace `/dev/boot` with the path of your USB drive!
+
     ```
     /sbin/parted -s -- /dev/boot mklabel gpt
     ```
@@ -100,11 +137,8 @@ To restore back to the factory UNVR-Pro firmware, you can do the following steps
 
 * Installation is Hard
     * Need to simplify the install process, this should be much easier once I can get latest GPL kernel source (no more uboot env stuff)
-* OpenMediaVault
-    * BTRFS is in TESTING
-        * Building an out-of-tree module for this using an OLD Unifi GPL release from https://github.com/fabianishere/udm-kernel
 * Reset Button
-    * Only works to reboot the system
+    * Only works to reboot the system, may wire this up to reset the WebUI password in OpenMediaVault down the road
 
 ## Disclaimer
 

--- a/genimage_initial.cfg
+++ b/genimage_initial.cfg
@@ -7,9 +7,9 @@ image boot.ext4 {
 }
 
 image rootfs.ext4 {
-	name = "debian"
+	name = "rootfs"
 	ext4 {
-		label = "root"
+		label = "rootfs"
 		use-mke2fs = true # Needed to prevent resize issues...
 	}
 	size = 3G

--- a/overlay/filesystem/etc/fstab
+++ b/overlay/filesystem/etc/fstab
@@ -1,2 +1,2 @@
-/dev/boot1      /boot   ext4    defaults   0   1
-/dev/boot2      /       ext4    defaults   0   1
+PARTLABEL=boot      /boot   ext4    defaults,ro   0   1
+PARTLABEL=rootfs    /       ext4    defaults      0   1

--- a/overlay/filesystem/etc/ld.so.conf.d/ubnt.conf
+++ b/overlay/filesystem/etc/ld.so.conf.d/ubnt.conf
@@ -1,1 +1,2 @@
+# Used on UNVRPRO for ulcmd
 /usr/lib/ubnt-fw

--- a/overlay/filesystem/etc/systemd/system/ulcmd.service
+++ b/overlay/filesystem/etc/systemd/system/ulcmd.service
@@ -1,11 +1,11 @@
 [Unit]
-Description=Daemon for MCU based LCM control
+Description=Unifi LED/ULCMD contoller
 Requires=ubnt-init.service
 Requires=mock-ubnt-api.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/ulcmd
+ExecStart=/usr/lib/init/boot/ubnt-ulcmd.sh
 KillMode=process
 Restart=on-failure
 RestartSec=2s

--- a/overlay/filesystem/usr/lib/init/boot/ubnt-ulcmd.sh
+++ b/overlay/filesystem/usr/lib/init/boot/ubnt-ulcmd.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# ULCMD wrapper, used to start ulcmd on the UNVR Pro, or setup the status LED on the UNVR-4
+
+case "$(ubnteeprom -systeminfo -key shortname)" in
+    "UNVRPRO")
+        # Is ulcmd running already? if so, assume it was not done via systemd so let's
+        # kill and respawn as this is our systemd entry script for the service, and we
+        # need to have it foregrounded as we act as the "daemon" here.
+        if ! pidof -q ulcmd; then
+            killall ulcmd
+        fi
+        # Restart ulcmd
+        exec ulcmd
+        ;;
+    "UNVR4")
+        # TODO: LED setup (2=white, 1=blue) against /sys/class/leds/ulogo_ctrl
+        # Start our "daemon" loop so systemd stays happy
+        while true; do
+            sleep 3600
+        done
+        ;;
+    *)
+        exit 1
+        ;;
+esac

--- a/overlay/filesystem/usr/lib/python3/dist-packages/ubnthelpers.py
+++ b/overlay/filesystem/usr/lib/python3/dist-packages/ubnthelpers.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import os
 from functools import lru_cache
 
 """

--- a/overlay/filesystem/usr/lib/udev/rules.d/60-persistent-storage-ubnt-boot.rules
+++ b/overlay/filesystem/usr/lib/udev/rules.d/60-persistent-storage-ubnt-boot.rules
@@ -1,0 +1,42 @@
+# Support for Ubiquiti /dev/boot devices with udev
+
+ACTION=="remove", GOTO="persistent_emmc"
+
+SUBSYSTEM!="block", GOTO="persistent_emmc"
+KERNEL!="boot*", GOTO="persistent_emmc"
+
+# For partitions import parent disk ID_* information, except ID_FS_*.
+#
+# This is particularly important on media where a filesystem superblock and
+# partition table are found on the same level, e.g. common Linux distro ISO
+# installation media.
+#
+# In the case where a partition device points to the same filesystem that
+# was detected on the parent disk, the ID_FS_* information is already
+# present on the partition devices as well as the parent, so no need to
+# propagate it. In the case where the partition device points to a different
+# filesystem, merging the parent ID_FS_ properties would lead to
+# inconsistencies, so we avoid doing so.
+ENV{DEVTYPE}=="partition", \
+  IMPORT{parent}="ID_[!F]*", IMPORT{parent}="ID_", \
+  IMPORT{parent}="ID_F[!S]*", IMPORT{parent}="ID_F", \
+  IMPORT{parent}="ID_FS[!_]*", IMPORT{parent}="ID_FS"
+
+# probe filesystem metadata of disks
+KERNEL!="sr*|mmcblk[0-9]boot[0-9]", IMPORT{builtin}="blkid"
+
+# by-label/by-uuid links (filesystem metadata)
+ENV{ID_FS_USAGE}=="filesystem|other|crypto", ENV{ID_FS_UUID_ENC}=="?*", SYMLINK+="disk/by-uuid/$env{ID_FS_UUID_ENC}"
+ENV{ID_FS_USAGE}=="filesystem|other|crypto", ENV{ID_FS_LABEL_ENC}=="?*", SYMLINK+="disk/by-label/$env{ID_FS_LABEL_ENC}"
+
+# by-path
+ENV{DEVTYPE}=="disk", DEVPATH!="*/virtual/*", IMPORT{builtin}="path_id"
+ENV{DEVTYPE}=="disk", ENV{ID_PATH}=="?*", SYMLINK+="disk/by-path/$env{ID_PATH}"
+ENV{DEVTYPE}=="partition", ENV{ID_PATH}=="?*", SYMLINK+="disk/by-path/$env{ID_PATH}-part%n"
+
+# by-partlabel/by-partuuid links (partition metadata)
+IMPORT{builtin}="blkid"
+ENV{ID_PART_ENTRY_UUID}=="?*", SYMLINK+="disk/by-partuuid/$env{ID_PART_ENTRY_UUID}"
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_NAME}=="?*", SYMLINK+="disk/by-partlabel/$env{ID_PART_ENTRY_NAME}"
+
+LABEL="persistent_emmc"

--- a/scripts/00_prereq_check.sh
+++ b/scripts/00_prereq_check.sh
@@ -21,6 +21,17 @@ if [ ! -d /sys/module/loop ]; then
     exit 1
 fi
 
+# Did we have a board set?
+if [ -z "${BOARD}" ]; then
+    echo "Error: BOARD is not set, so we don't know what we are building for! Exiting..."
+    echo "Please review the README.md on usage!"
+    exit 1
+elif [ -z "${firmware_filename}" ]; then
+    # Board is set, make sure it's a board we support
+    echo "Error: Invalid BOARD value of ${BOARD}. Please review the README.md on usage!"
+    exit 1
+fi
+
 # Validate FW is downloaded
 if ! [ -f "${root_path}/unifi-firmware/${firmware_filename}" ]; then
     echo "Error: File ${firmware_filename} does not exist in ./unifi-firmware! Exiting..."

--- a/scripts/01_pre_docker.sh
+++ b/scripts/01_pre_docker.sh
@@ -15,11 +15,11 @@ else
 fi
 
 # Extract the goodies
-${scripts_path}/ubnt-fw-parse.py "${root_path}/unifi-firmware/${firmware_filename}" "${build_path}/fw-extract"
+${scripts_path}/ubnt-fw-parse.py "${root_path}/unifi-firmware/${firmware_filename}" "${build_path}/fw-extract/${firmware_filename%.bin}"
 
 # Extract the squashfs rootfs
 echo "Extracting unifi rootfs as root..."
-sudo unsquashfs -f -d "${build_path}/fw-extract/rootfs" "${build_path}/fw-extract/rootfs.bin"
+sudo unsquashfs -f -d "${build_path}/fw-extract/${BOARD}-rootfs" "${build_path}/fw-extract/${firmware_filename%.bin}/rootfs.bin"
 
 # Always build to pickup changes/updates/improvements
 debug_msg "Building ${docker_tag}"

--- a/scripts/03_docker.sh
+++ b/scripts/03_docker.sh
@@ -67,7 +67,7 @@ sudo rm -f ${build_path}/rootfs/placeholder ${build_path}/rootfs/boot/placeholde
 # SAFETY NET - trap it, even tho we have makefile with set -e
 debug_msg "Docker: debootstraping..."
 trap "sudo umount ${build_path}/rootfs/boot; sudo umount ${build_path}/rootfs; sudo losetup -d ${boot_loop_dev}; sudo losetup -d ${rootfs_loop_dev}" SIGINT SIGTERM
-docker run --ulimit nofile=1024 --rm --privileged --cap-add=ALL -v /dev:/dev -v "${root_path}:/repo:Z" -it ${docker_tag} /repo/scripts/docker/run_debootstrap.sh
+docker run --ulimit nofile=1024 --rm --privileged --cap-add=ALL -v /dev:/dev -v "${root_path}:/repo:Z" -e BOARD="${BOARD}" -it ${docker_tag} /repo/scripts/docker/run_debootstrap.sh
 
 debug_msg "Note: You might be asked for your password for losetup and umount since we are cleaning up mounts..."
 debug_msg "Cleaning up..."

--- a/scripts/04_post_docker.sh
+++ b/scripts/04_post_docker.sh
@@ -14,7 +14,7 @@ fi
 mkdir -p ${build_path}/final
 
 # Kick off the docker to do the magics for us, since we need genimage
-docker run --rm -v "${root_path}:/repo:Z" -it ${docker_tag} /repo/scripts/docker/run_mkimage_final.sh
+docker run --rm -v "${root_path}:/repo:Z" -e BOARD="${BOARD}" -it ${docker_tag} /repo/scripts/docker/run_mkimage_final.sh
 
 # Just create our final dir and move bits over
 TIMESTAMP=`date +%Y%m%d-%H%M`

--- a/scripts/docker/bootstrap/001-bootstrap
+++ b/scripts/docker/bootstrap/001-bootstrap
@@ -69,6 +69,7 @@ jq --null-input --compact-output \
     omv-confdbadm update "conf.system.network.interface" -
 # Set hostname
 omv-confdbadm update "conf.system.network.dns" "{\"hostname\": \"unvr-nas\"}"
+sed -i "s|myhostname = .*|myhostname = unvr-nas|g" /etc/postfix/main.cf
 
 # Cleanup stuff we don't want floating around
 apt-get autoclean || true

--- a/scripts/docker/run_mkimage_final.sh
+++ b/scripts/docker/run_mkimage_final.sh
@@ -21,8 +21,8 @@ genimage                         \
 	--inputpath "${build_path}/final"  \
 	--outputpath "${build_path}/final" \
 	--config "${build_path}/genimage.cfg"
-mv ${build_path}/final/emmc.img ${build_path}/final/debian-UNVRPRO.img
-gzip ${build_path}/final/debian-UNVRPRO.img
+mv ${build_path}/final/emmc.img ${build_path}/final/debian-${BOARD}.img
+gzip ${build_path}/final/debian-${BOARD}.img
 rm -rf /tmp/genimage-initial-tmppath # Cleanup
 
 # Cleanup

--- a/scripts/vars.sh
+++ b/scripts/vars.sh
@@ -6,9 +6,17 @@ build_path="${root_path}/BuildEnv"
 # Docker image name
 docker_tag=unvr-nas:builder
 
-# Expected UNVR Firmware and hash
-firmware_filename="f449-UNVRPRO-4.0.3-fdec2c4f-1855-4eb6-8711-e22f8f904922.bin"
-firmware_md5="5dcdc03bdec1524767007fcd12e81777"
+# Expected UNVR Firmware(s) and hash(s)
+UNVR_firmware_filename="7f7c-UNVR-4.0.5-1d4b9c7d-926b-4ef4-88c6-23978c2455a8.bin"
+UNVR_firmware_md5="3bab9336619125e7fe6e4af7484a79dc"
+UNVRPRO_firmware_filename="b0a3-UNVRPRO-4.0.5-f221e29e-3405-4cb9-8d13-0f117d9cc3a1.bin"
+UNVRPRO_firmware_md5="f6aec555fa79c4e083168ec2aac4a71a"
+
+# Render our board out
+fwfnvar="${BOARD}_firmware_filename"
+firmware_filename="${!fwfnvar}"
+fwmd5var="${BOARD}_firmware_md5"
+firmware_md5="${!fwmd5var}"
 
 # Toolchain
 toolchain_url="https://developer.arm.com/-/media/Files/downloads/gnu/12.2.rel1/binrel/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-linux-gnu.tar.xz"

--- a/tools/ubnteeprom/main.go
+++ b/tools/ubnteeprom/main.go
@@ -26,7 +26,7 @@ var UBNTDeviceMap = []UBNTSysMap{
 		name:      "UniFi-NVR-4",
 		shortname: "UNVR4",
 		cpu:       "AL324V2",
-		sysid:     "ea16",
+		sysid:     "ea16", // USB drive (non emmc) variant
 	},
 	{
 		name:      "UniFi-NVR-4",

--- a/unifi-firmware/README.md
+++ b/unifi-firmware/README.md
@@ -1,6 +1,12 @@
 # unifi-firmware
 
-Please place the UNVR-Pro firmware in this directory.
+Please place the UNVR/UNVR Pro firmware in this directory.
 
-Name: f449-UNVRPRO-4.0.3-fdec2c4f-1855-4eb6-8711-e22f8f904922.bin
-MD5Sum: 5dcdc03bdec1524767007fcd12e81777
+* UNVR:
+  * Name: [7f7c-UNVR-4.0.5-1d4b9c7d-926b-4ef4-88c6-23978c2455a8.bin](https://community.ui.com/releases/UniFi-OS-Network-Video-Recorders-4-0-5/7c734ca2-72e2-4747-96a0-e3a376cf96aa)
+  * MD5Sum: 3bab9336619125e7fe6e4af7484a79dc
+
+
+* UNVR Pro:
+  * Name: [b0a3-UNVRPRO-4.0.5-f221e29e-3405-4cb9-8d13-0f117d9cc3a1.bin](https://community.ui.com/releases/UniFi-OS-Network-Video-Recorders-4-0-5/7c734ca2-72e2-4747-96a0-e3a376cf96aa)
+  * MD5Sum: f6aec555fa79c4e083168ec2aac4a71a


### PR DESCRIPTION
* Move partition mounts to PARTLABEL instead of paths
* Add dual firmware building support, specify the build type using the BOARD env var when using make
* Update to Unifi 4.0.5 pre-release firmware
* Move ulcmd init to be our "user interface" setup script, will handle LEDs on the UNVR4 in the future
* Update README with updated instructions